### PR TITLE
Updated library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Depends on LiquidChrystal library.
 category=Display
 url=https://github.com/wloche/LcdProgressBar
 architectures=*
-includes=LiquidCrystal.h
+includes=LcdProgressBar.h, LiquidCrystal.h


### PR DESCRIPTION
Added "LcdProgressBar.h" to includes in library.properties.  Without it when you go to Sketch > Include Library in the Arduino IDE it will only include LiquidCrystal.h